### PR TITLE
Add email address extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 
 # Ignore Lock file since it is a lib
 /mix.lock
+
+# Ignore language server dir
+/.elixir_ls

--- a/lib/phoenix_client_ssl/plug/extract_email_address.ex
+++ b/lib/phoenix_client_ssl/plug/extract_email_address.ex
@@ -1,0 +1,50 @@
+defmodule PhoenixClientSsl.Plug.ExtractEmailAddress do
+  @moduledoc """
+  This Plug extracts the Common Name of a certificate in eligible connections.
+
+  Best used together with `PhoenixClientSsl.Plug.ExtractClientCertificate`.
+
+  ### Installation
+
+  The plug can be installed in any `pipeline` of the Phoenix Router. It takes no options.
+
+      defmodule Aceme.Web.Router do
+        use Acme.Web, :router
+
+        pipeline :api do
+          plug :accepts, ["json"]
+
+          # This line enables the plug
+          plug PhoenixClientSsl.Plug.EmailAdress
+        end
+
+        scope "/", Acme.Web do
+          pipe_through :api
+
+          get "/", SomeController, :index
+        end
+      end
+
+  """
+
+  import Plug.Conn
+  alias Plug.Conn
+
+  @doc """
+  No configuration needed.
+  """
+  def init([]), do: %{}
+
+  @doc """
+  Extract the Common Name of a certificate in eligible connections.
+
+  Skipping if either the common name is already set or the connection has no client certificate.
+  """
+  def call(%Conn{private: %{client_certificate_email_address: _}} = conn, _options), do: conn
+
+  def call(%Conn{private: %{client_certificate: certificate}} = conn, _options) do
+    put_private(conn, :client_certificate_email_address, PublicKeySubject.email_address(certificate))
+  end
+
+  def call(conn, _options), do: conn
+end

--- a/lib/phoenix_client_ssl/plug/extract_email_address.ex
+++ b/lib/phoenix_client_ssl/plug/extract_email_address.ex
@@ -43,7 +43,11 @@ defmodule PhoenixClientSsl.Plug.ExtractEmailAddress do
   def call(%Conn{private: %{client_certificate_email_address: _}} = conn, _options), do: conn
 
   def call(%Conn{private: %{client_certificate: certificate}} = conn, _options) do
-    put_private(conn, :client_certificate_email_address, PublicKeySubject.email_address(certificate))
+    put_private(
+      conn,
+      :client_certificate_email_address,
+      PublicKeySubject.email_address(certificate)
+    )
   end
 
   def call(conn, _options), do: conn

--- a/lib/phoenix_client_ssl/plug/extract_email_address.ex
+++ b/lib/phoenix_client_ssl/plug/extract_email_address.ex
@@ -1,6 +1,6 @@
 defmodule PhoenixClientSsl.Plug.ExtractEmailAddress do
   @moduledoc """
-  This Plug extracts the Common Name of a certificate in eligible connections.
+  This Plug extracts the `emailAddress` of a certificate in eligible connections.
 
   Best used together with `PhoenixClientSsl.Plug.ExtractClientCertificate`.
 
@@ -36,9 +36,9 @@ defmodule PhoenixClientSsl.Plug.ExtractEmailAddress do
   def init([]), do: %{}
 
   @doc """
-  Extract the Common Name of a certificate in eligible connections.
+  Extract the emailAddress of a certificate in eligible connections.
 
-  Skipping if either the common name is already set or the connection has no client certificate.
+  Skipping if either the email address is already set or the connection has no client certificate.
   """
   def call(%Conn{private: %{client_certificate_email_address: _}} = conn, _options), do: conn
 

--- a/lib/public_key_subject.erl
+++ b/lib/public_key_subject.erl
@@ -13,6 +13,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -export ([common_name/1,
+          email_address/1,
           pkix_subject_id/1]).
 
 %%--------------------------------------------------------------------
@@ -44,6 +45,23 @@ common_name({rdnSequence, Sequence}) ->
   end;
 common_name(Cert) ->
   common_name(pkix_subject_id(Cert)).
+
+%%--------------------------------------------------------------------
+-spec email_address(Cert::{rdnSequence, [#'AttributeTypeAndValue'{}]} | binary() | #'OTPCertificate'{}) -> binary().
+
+%
+%% Description: Returns the email address.
+%%--------------------------------------------------------------------
+
+email_address({rdnSequence, Sequence}) ->
+  case rdn_part(Sequence, ?'id-emailAddress') of
+    error ->
+      error;
+    Other ->
+      Other
+  end;
+email_address(Cert) ->
+  email_address(pkix_subject_id(Cert)).
 
 %%--------------------------------------------------------------------
 -spec rdn_part([#'AttributeTypeAndValue'{}], any()) -> any().

--- a/lib/public_key_subject.ex
+++ b/lib/public_key_subject.ex
@@ -21,6 +21,29 @@ defmodule PublicKeySubject do
   defdelegate common_name(cert_or_rdn_sequence), to: :public_key_subject
 
   @doc """
+  Returns the email address.
+
+  ### Examples
+
+      iex> PublicKeySubject.email_address({:rdnSequence,
+      ...>                               [[{:AttributeTypeAndValue, {2, 5, 4, 3}, {:printableString, "foo.bar.baz"}}],
+      ...>                                [{:AttributeTypeAndValue, {2, 5, 4, 6}, 'CH'}],
+      ...>                                [{:AttributeTypeAndValue, {1, 2, 840, 113_549, 1, 9, 1}, 'jonatan@maennchen.ch'}]]})
+      "jonatan@maennchen.ch"
+
+      iex> der_path = Path.join([Application.app_dir(:phoenix_client_ssl), "priv", "test", "foo.bar.baz.der"])
+      iex> PublicKeySubject.email_address(File.read!(der_path))
+      "jonatan@maennchen.ch"
+
+  """
+  def email_address(cert_or_rdn_sequence) do
+    case :public_key_subject.email_address(cert_or_rdn_sequence) do
+        email_address when is_list(email_address) -> to_string(email_address)
+        email_address -> email_address
+    end
+  end
+
+  @doc """
   Returns the certificates subject.
 
   ### Examples

--- a/lib/public_key_subject.ex
+++ b/lib/public_key_subject.ex
@@ -38,8 +38,8 @@ defmodule PublicKeySubject do
   """
   def email_address(cert_or_rdn_sequence) do
     case :public_key_subject.email_address(cert_or_rdn_sequence) do
-        email_address when is_list(email_address) -> to_string(email_address)
-        email_address -> email_address
+      email_address when is_list(email_address) -> to_string(email_address)
+      email_address -> email_address
     end
   end
 

--- a/test/phoenix_client_ssl/plug/extract_email_address_test.exs
+++ b/test/phoenix_client_ssl/plug/extract_email_address_test.exs
@@ -1,0 +1,52 @@
+defmodule PhoenixClientSsl.Plug.ExtractEmailAddressTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  alias PhoenixClientSsl.Plug.ExtractEmailAddress
+  alias Plug.Conn
+
+  doctest ExtractEmailAddress
+
+  @otp_cert [Application.app_dir(:phoenix_client_ssl), "priv", "test", "foo.bar.baz.der"]
+            |> Path.join()
+            |> File.read!()
+            |> :public_key.pkix_decode_cert(:otp)
+
+  describe "init/1" do
+    test "empty config passes" do
+      assert ExtractEmailAddress.init([]) == %{}
+    end
+
+    test "fails with given configuration" do
+      assert_raise(FunctionClauseError, fn ->
+        ExtractEmailAddress.init(foo: :bar)
+      end)
+    end
+  end
+
+  describe "call/2" do
+    test "skipps with already configure email address" do
+      conn = %Conn{
+        private: %{client_certificate: @otp_cert, client_certificate_email_address: :foo}
+      }
+
+      assert %Conn{private: %{client_certificate_email_address: :foo}} =
+               ExtractEmailAddress.call(conn, %{})
+    end
+
+    test "extracts email address" do
+      conn = %Conn{private: %{client_certificate: @otp_cert}}
+
+      assert %Conn{private: %{client_certificate_email_address: "jonatan@maennchen.ch"}} =
+               ExtractEmailAddress.call(conn, %{})
+    end
+
+    test "skips with missing certificate" do
+      conn = %Conn{}
+
+      assert %Conn{private: private} = ExtractEmailAddress.call(conn, %{})
+      refute private[:client_certificate_email_address]
+    end
+  end
+end

--- a/test/public_key_subject_test.exs
+++ b/test/public_key_subject_test.exs
@@ -56,6 +56,29 @@ defmodule PublicKeySubjectTest do
     end
   end
 
+  describe "email_address/1" do
+    for {expected, data} <- @test_sequences do
+      @data data
+      test "correct output for #{expected}" do
+        assert PublicKeySubject.email_address(@data) === "jonatan@maennchen.ch"
+      end
+    end
+
+    test "sequence without email address" do
+      assert PublicKeySubject.email_address({:rdnSequence, []}) == :error
+    end
+
+    test "with cert string" do
+      assert PublicKeySubject.email_address(@der_cert) == "jonatan@maennchen.ch"
+    end
+
+    test "with otp cert" do
+      cert = :public_key.pkix_decode_cert(@der_cert, :otp)
+
+      assert PublicKeySubject.email_address(cert) == "jonatan@maennchen.ch"
+    end
+  end
+
   describe "pkix_subject_id/1" do
     test "with cert string" do
       assert PublicKeySubject.pkix_subject_id(@der_cert) ==


### PR DESCRIPTION
Thank you for your effort in providing this package. We extended the package because we want to access the email address defined in the cert.